### PR TITLE
Disable local auth for Azure OpenAI

### DIFF
--- a/infra/modules/ai/cognitiveservices.bicep
+++ b/infra/modules/ai/cognitiveservices.bicep
@@ -5,6 +5,8 @@ param tags object = {}
 param customSubDomainName string = name
 param deployments array = []
 param kind string = 'OpenAI'
+
+param disableLocalAuth bool = true // Only allow access to Azure OpenAI via managed identity
 param publicNetworkAccess string = 'Disabled'
 param sku object = {
   name: 'S0'
@@ -36,6 +38,7 @@ resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   tags: union(tags, { 'azd-service-name': name })
   kind: kind
   properties: {
+    disableLocalAuth: disableLocalAuth 
     customSubDomainName: customSubDomainName
     publicNetworkAccess: publicNetworkAccess
     networkAcls: {


### PR DESCRIPTION
Even though we don't expose direct access to the Azure OpenAI resource, it would be good to disable local auth (key). Best practice for production is to use managed identities / AAD to access the resource.

**Copilot summary:**
This pull request includes a change to the `cognitiveservices.bicep` file in the `infra/modules/ai` directory. The most important change is the addition of a new property called `disableLocalAuth`, which allows the option to disable local authentication for Azure OpenAI services.

* <a href="diffhunk://#diff-06a25095f2f862128dad4d4e877ba672712d91f4bcf5df846761be2792385478R41">`infra/modules/ai/cognitiveservices.bicep`</a>: Added a new property called `disableLocalAuth` to disable local authentication for Azure OpenAI services.